### PR TITLE
./gradlew build does not build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ playground/output/
 # Build temporary testing and building directory
 /tmp
 
+# Setup for jenv
+.java-version
+
 #Claude.md
 Claude.md
 agent.md

--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@ Jade is a Java decompiler that aims for high reliability through extensive testi
 
 ## Requirements
 
-The only requirement is to have a copy of the [Java
-JRE](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
-installed so that `java` can be run.
+- Install [Java](https://www.oracle.com/java/technologies/downloads/)
+- Install [Gradle](https://docs.gradle.org/current/userguide/installation.html)
 
-TODO: it is tested on Java version 19
+Jade uses [Gradle 8.11.1](gradle/wrapper/gradle-wrapper.properties), so you will not be able to run `./gradlew` if your Java version is >= 24.
+You can check if your Java version is compatible [here](https://docs.gradle.org/current/userguide/compatibility.html).
+If you machine has multiple Java installations, consider using [`jenv`](https://github.com/jenv/jenv) to manage the environment.
 
 Building the tool automatically downloads the other parts that are needed.
+
+TODO: It has only been tested on Java version 19; Consider testing other Java versions as well
+TODO: Consider using Docker to avoid "works on my machine" issues
 
 ## Building
 

--- a/src/main/kotlin/org/ucombinator/jade/decompile/Decompile.kt
+++ b/src/main/kotlin/org/ucombinator/jade/decompile/Decompile.kt
@@ -1,6 +1,7 @@
 package org.ucombinator.jade.decompile
 
 import com.github.javaparser.ast.CompilationUnit
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.ClassNode
@@ -73,7 +74,7 @@ object Decompile {
 
       val file = filePathMap[topLevel]!!
       log.info { "Writing top-level class [${i + 1} of ${topLevelClasses.size}] $topLevel" }
-      val cu = compilationUnits[topLevel]!!
+      val compilationUnit = compilationUnits[topLevel]!!
       val classFileName = file.getName()
       if (!classFileName.contains(suffix)) {
         throw Exception("Invalid file name: file $classFileName does not end with .class")

--- a/src/main/kotlin/org/ucombinator/jade/decompile/DecompileStatement.kt
+++ b/src/main/kotlin/org/ucombinator/jade/decompile/DecompileStatement.kt
@@ -190,7 +190,7 @@ object DecompileStatement {
         // TODO: constructor?
         pendingInside.remove(currentInsn)
         val outEdges = removeOutEdges(currentInsn!!)
-        val (_, decompiled) = DecompileInsn.decompileInsn(currentInsn!!.insn, ssa, classNode, thisVars)
+        val (_, decompiled) = DecompileInsn.decompileInsn(currentInsn!!.insn, ssa, classNode)
         val next = currentInsn?.next()
         val insnIsALoopHead =
           cfg.graph.incomingEdgesOf(currentInsn).any { structure.backEdges.contains(it) }


### PR DESCRIPTION
Running `./gradlew build` does not work on my machine. There are 2 main reasons:

1. I was running Java 26, which is not compatible with Gradle 8.11.1. I have updated the README to be more explicit with the requirements.
2. There seems to be issues in `Decompile.kt` and `DecompileStatement.kt`. I'm not sure if these are caused by uncommitted changes, but I have added minimal fixes so that `./gradlew build` succeeds.